### PR TITLE
Set up redirect app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # GOV.UK Design System Redirect
+
+This is a simple CloudFoundry app that redirects all requests to our service
+domain.
+
+We use it to redirect the cloudapps.digital domain we used during private beta
+(which may be bookmarked by our private beta partners, and is referred to in
+documentation ) to our service domain (design-system.service.gov.uk)
+
+## Licence
+
+Unless stated otherwise, the codebase is released under the MIT License. This
+covers both the codebase and any sample code in the documentation. The
+documentation is &copy; Crown copyright and available under the terms of the
+Open Government 3.0 licence.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,11 @@
+---
+applications:
+- name: govuk-design-system-redirect
+  # NGINX requires 20 MB of RAM to serve static assets. Reduce RAM allocation
+  # from the default 1 GB allocated to containers by default to 64M.
+  memory: 64M
+  # PaaS don't currently support the nginx buildpack so we have to reference it
+  # by GitHub URL
+  #
+  # https://docs.cloud.service.gov.uk/#how-to-use-custom-buildpacks
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v0.0.5

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+worker_processes 1;
+daemon off;
+
+error_log stderr;
+events { worker_connections 1024; }
+
+pid /tmp/nginx.pid;
+
+http {
+  charset utf-8;
+
+  # Configure logging
+
+  log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
+  access_log /dev/stdout cloudfoundry;
+
+  # Set up a server!
+
+  server {
+    listen {{.Port}} default_server;
+    return 301 https://design-system.service.gov.uk$request_uri;
+  }
+}


### PR DESCRIPTION
We need to redirect the cloudapps.digital domain we used during private beta (which may be bookmarked by our private beta partners, and is referred to in documentation ) to our service domain (design-system.service.gov.uk)

This is currently deployed to https://govuk-design-system-redirect.cloudapps.digital for testing.

https://trello.com/c/A9kDu8BR/1124-create-basic-paas-site-that-redirects-requests-to-the-new-url