### PR TITLE
Update build pack so the application succeeds

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,5 +7,5 @@ applications:
   # PaaS don't currently support the nginx buildpack so we have to reference it
   # by GitHub URL
   #
-  # https://docs.cloud.service.gov.uk/#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v0.0.5
+  # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.1

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,8 +4,6 @@ daemon off;
 error_log stderr;
 events { worker_connections 1024; }
 
-pid /tmp/nginx.pid;
-
 http {
   charset utf-8;
 
@@ -17,7 +15,7 @@ http {
   # Set up a server!
 
   server {
-    listen {{.Port}} default_server;
+    listen {{port}} default_server;
     return 301 https://design-system.service.gov.uk$request_uri;
   }
 }


### PR DESCRIPTION
GOV.UK PaaS moved to cflinuxfs3 in March, which means this build pack no longer works.