### PR TITLE
Use nginx buildpack from PaaS

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,8 +4,4 @@ applications:
   # NGINX requires 20 MB of RAM to serve static assets. Reduce RAM allocation
   # from the default 1 GB allocated to containers by default to 64M.
   memory: 64M
-  # PaaS don't currently support the nginx buildpack so we have to reference it
-  # by GitHub URL
-  #
-  # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.3
+  buildpack: nginx_buildpack


### PR DESCRIPTION
Make keeping nginx up-to-date not our problem...

---

Note that we don't have a deploy pipeline for this, so whoever merges this should also make sure to deploy it to the [govuk-design-system/design-system space in PaaS](https://admin.cloud.service.gov.uk/organisations/a27b3e36-e041-464d-85a9-c9bef5201c97/spaces/a13048ea-5ac1-4ff1-8aa3-d6a2e2e8be22/applications).